### PR TITLE
[47기 신동현] Modify : kakao 토큰이 아닌 인가코드를 받아오도록 수정

### DIFF
--- a/api/controllers/userController.js
+++ b/api/controllers/userController.js
@@ -2,9 +2,9 @@ import { userService } from '../services/index.js';
 import { catchAsync } from '../utils/error.js';
 
 const kakaoLogin = catchAsync(async (req, res) => {
-  const kakaoToken = req.headers.authorization;
+  const kakaoCode = req.query.code;
 
-  const accessToken = await userService.kakaoLogin(kakaoToken);
+  const accessToken = await userService.kakaoLogin(kakaoCode);
 
   return res.status(200).json({ accessToken: accessToken });
 });

--- a/api/routes/userRouter.js
+++ b/api/routes/userRouter.js
@@ -3,6 +3,6 @@ import { userController } from '../controllers/index.js';
 
 const userRouter = express.Router();
 
-userRouter.post('/kakaoLogin', userController.kakaoLogin);
+userRouter.get('/kakaoLogin', userController.kakaoLogin);
 
 export { userRouter };

--- a/api/services/userService.js
+++ b/api/services/userService.js
@@ -3,12 +3,29 @@ import axios from 'axios';
 
 import { userDao } from '../models/index.js';
 
-const kakaoLogin = async (kakaoToken) => {
+const kakaoLogin = async (kakaoCode) => {
+  const clientId = process.env.CLIENT_ID;
+  const redirectUri = process.env.REDIRECT_URI;
+
+  const kakaoToken = await axios({
+    method: 'POST',
+    url: 'https://kauth.kakao.com/oauth/token',
+    headers: {
+      'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
+    },
+    data: {
+      grant_type: 'authorization_code',
+      client_id: clientId,
+      redirect_uri: redirectUri,
+      code: kakaoCode,
+    },
+  });
+
   const result = await axios({
     method: 'GET',
     url: 'https://kapi.kakao.com/v2/user/me',
     headers: {
-      Authorization: `Bearer ${kakaoToken}`,
+      Authorization: `Bearer ${kakaoToken.data.access_token}`,
       'Content-Type': 'application/x-www-form-urlencoded;charset=utf-8',
     },
   });

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "tests"
   },
   "scripts": {
+    "test": "DOTENV_CONFIG_PATH=.env.test jest --setupFiles=dotenv/config",
     "start": "nodemon server.js"
   },
   "repository": {


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [ ] 기능 추가
- [ ] 데이터베이스 작업
- [ ] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표 - 해당 브랜치(PR)에서 구현하고자 하는 하나의 목표 작성
- 클라이언트에게서 받은 카카오 인가코드를 사용하여 카카오 토큰을 발급받은 후 해당 user의 data를 DB에 저장하는 기능 구현

<br />

## :: 구현 사항 설명 - 해당 브랜치(PR)에서 작업한 내용 작성
- 유저의 data(kakaoId, name, email, age, gender)를 DB에 저장
- jwt를 사용하여 토큰 발급


<br />

## :: 테스트 결과 이미지
1. Server가 잘 동작하는지 확인할 수 있는 Terminal 캡쳐 이미지
2. Postman(Client Tool)을 이용한 API 테스트 결과 이미지
3. 작성한 Test Code가 잘 통과했는지 확인할 수 있는 이미지
4. DB 작업 PR인 경우 Table 생성 및 수정 결과에 대해 확인할 수 있는 이미지

<br />

## :: 기타 질문 및 특이 사항
- 제가 작성한 함수의 로직이 너무 복잡하다고 생각이 됩니다. 더 효율적인 방법이 없을까요? (예시)
